### PR TITLE
docs: clarify light/dark mode toggle description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A comprehensive health analytics platform featuring AI-powered glucose predictio
 
 - **AI Glucose Prediction**: XGBoost model with 92.5% accuracy (R² = 0.925)
 - **Interactive Dashboard**: Modern Streamlit interface with premium styling
-- **Theme System**: Automatic light/dark mode with iOS-style toggle
+- **Theme System**: Light/dark mode controlled with a button-based toggle
 - **Advanced Analytics**: Correlation analysis, risk assessment, feature importance
 - **Patient Management**: Individual patient tracking and analysis
 - **Report Generation**: Professional clinical reports with download capability (JSON, HTML, PDF)


### PR DESCRIPTION
## Summary
- clarify that theme system uses a button-based light/dark mode toggle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c029677534832a87b30219684d3141