### PR TITLE
Add tests for theme toggle button

### DIFF
--- a/healthpulse_app.py
+++ b/healthpulse_app.py
@@ -515,6 +515,10 @@ def create_ios_theme_toggle():
         label_visibility="hidden",
     )
 
+def create_theme_toggle_button():
+    """Wrapper for backward compatibility"""
+    create_ios_theme_toggle()
+
 def create_logo():
     """Create animated logo"""
     st.markdown("""

--- a/tests/test_theme_toggle.py
+++ b/tests/test_theme_toggle.py
@@ -1,0 +1,27 @@
+import pytest
+import streamlit as st
+
+from healthpulse_app import create_theme_toggle_button
+
+
+def test_theme_toggle_button(monkeypatch):
+    """Ensure theme toggles between light and dark"""
+    st.session_state.clear()
+    st.session_state.theme = "light"
+    st.session_state.theme_toggle = True
+
+    def fake_toggle(*args, **kwargs):
+        if "on_change" in kwargs and kwargs["on_change"]:
+            kwargs["on_change"]()
+        return st.session_state.theme_toggle
+
+    monkeypatch.setattr(st, "toggle", fake_toggle)
+    monkeypatch.setattr(st, "rerun", lambda: None)
+
+    create_theme_toggle_button()
+    assert st.session_state.theme == "dark"
+
+    st.session_state.theme_toggle = False
+    create_theme_toggle_button()
+    assert st.session_state.theme == "light"
+


### PR DESCRIPTION
## Summary
- add wrapper for theme toggle button
- test theme toggle flips session state theme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02960f304832a96e9db1c1391f460